### PR TITLE
Update Snapcraft Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: cibuilds/snapcraft:core18
+      - image: cibuilds/snapcraft:core20
     steps:
       - checkout
       - attach_workspace:
@@ -124,4 +124,4 @@ jobs:
                 command: |
                   # Snapcraft Tokens are valid for 1 year. This one expires August 10th, 2021
                   echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage | snapcraft login --with -
-                  snapcraft push *.snap --release=stable
+                  snapcraft upload *.snap --release=stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 
   Starting a new project? You can check for name availability on these platforms.
 license: MIT
-base: core18
+base: core20
 grade: stable
 confinement: strict
 adopt-info: para


### PR DESCRIPTION
Also updated `snapcraft push` to `snapcraft upload` due to [deprecation](https://snapcraft.io/docs/deprecation-notices/dn11).