### PR TITLE
Use orb for GoReleaser.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,25 @@
 version: 2.1
 
+orbs:
+  gor: hubci/goreleaser@0.2
+
 workflows:
   main:
     jobs:
       - test
-      - build-binaries
+      - gor/release:
+          version: "0.147.1"
+          go-version: "1.15.5"
+          dry-run: true
+          post-steps:
+            - persist_to_workspace:
+                root: "."
+                paths:
+                  - "dist"
       - build-snap:
           name: "Build Snap"
           requires:
-            - build-binaries
+            - gor/release
   release:
     jobs:
       - test:
@@ -18,18 +29,24 @@ workflows:
             tags:
               # Simplified SemVer regex
               only: /^v\d+\.\d+\.\d+$/
-      - build-binaries:
+      - gor/release:
+          version: "0.147.1"
+          go-version: "1.15.5"
           filters:
             branches:
               ignore: /.*/
             tags:
               # Simplified SemVer regex
               only: /^v\d+\.\d+\.\d+$/
-          publish: true
+          post-steps:
+            - persist_to_workspace:
+                root: "."
+                paths:
+                  - "dist"
       - build-snap:
           name: "Build 'stable' Snap"
           requires:
-            - build-binaries
+            - gor/release
           filters:
             branches:
               ignore: /.*/
@@ -57,36 +74,6 @@ jobs:
           key: go-mod-v1
           paths:
             - "/go/pkg/mod"
-  build-binaries:
-    parameters:
-      publish:
-        type: boolean
-        default: false
-    docker:
-      - image: cimg/go:1.15.5
-    steps:
-      - checkout
-      - run:
-          name: "Install GoReleaser"
-          command: |
-            curl -sSL "https://github.com/goreleaser/goreleaser/releases/download/v0.147.1/goreleaser_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin goreleaser
-            goreleaser --version
-      - unless:
-          condition: << parameters.publish >>
-          steps:
-            - run:
-                name: "Build Binaries with GoReleaser"
-                command: goreleaser --snapshot --skip-publish --rm-dist
-      - when:
-          condition: << parameters.publish >>
-          steps:
-            - run:
-                name: "Build Binaries & Publish with GoReleaser"
-                command: goreleaser
-      - persist_to_workspace:
-          root: "."
-          paths:
-            - "dist"
   build-snap:
     parameters:
       publish-edge:


### PR DESCRIPTION
This PR allows us to maintain GoReleaser with an orb. Makes it slightly easier while reducing the number of lines of our config.