### PR TITLE
Add support for arm64 architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X github.com/felicianotech/para/para/cmd.version={{ .Version }} -extldflags "-static"
 


### PR DESCRIPTION
Adding general support for arm64, though the main purpose of this PR is
to enable Apple Silicon support specifically.